### PR TITLE
Fix/accu 2579

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/**/*
 .tern-port
 .projectile
 .tern-project
+*.log

--- a/errors.js
+++ b/errors.js
@@ -12,7 +12,8 @@ module.exports = create => {
                 return new PortHTTP({
                     message: (response.body && response.body.message) || 'HTTP error',
                     statusCode: response.statusCode,
-                    statusMessage: response.statusText,
+                    statusText: response.statusText,
+                    statusMessage: response.statusMessage,
                     validation: response.body && response.body.validation,
                     debug: response.body && response.body.debug
                 });

--- a/index.js
+++ b/index.js
@@ -120,12 +120,10 @@ module.exports = function({parent}) {
                         payload: body
                     };
                     if (response.statusCode < 200 || response.statusCode >= 300) {
-                        this.log && this.log.error && this.log.error('Http client request error! body: ' + body + ', statusCode: ' +
-                            response.statusCode + ', statusMessage: ' + response.statusMessage);
-                        let error;
-                        error = errors.http(response);
+                        let error = errors.http(response);
                         error.code = response.statusCode;
                         error.body = response.body;
+                        this.log && this.log.error && this.log.error(error);
                         reject(error);
                     } else if (!body || body === '') { // if response is empty
                         correctResponse.payload = ((parseResponse) ? {} : body);


### PR DESCRIPTION
Pass real javascript exceptions to `log.error` so that sentry can collect them properly.