### PR TITLE
Allow certain status codes in response

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,29 @@ module.exports = function({parent}) {
                         let error = errors.http(response);
                         error.code = response.statusCode;
                         error.body = response.body;
-                        this.log && this.log.error && this.log.error(error);
+                        let shouldLog = true;
+                        if (msg.disableStatusCodeLog) {
+                            switch (msg.disableStatusCodeLog.constructor.name) {
+                                case 'Number':
+                                    if (msg.disableStatusCodeLog === response.statusCode) {
+                                        shouldLog = false;
+                                    }
+                                    break;
+                                case 'Array':
+                                    if (msg.disableStatusCodeLog.indexOf(response.statusCode) !== -1) {
+                                        shouldLog = false;
+                                    }
+                                    break;
+                                case 'RegExp':
+                                    if (msg.disableStatusCodeLog.test(response.statusCode)) {
+                                        shouldLog = false;
+                                    }
+                                    break;
+                                default:
+                                    break;
+                            }
+                        }
+                        shouldLog && this.log && this.log.error && this.log.error(error);
                         reject(error);
                     } else if (!body || body === '') { // if response is empty
                         correctResponse.payload = ((parseResponse) ? {} : body);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "changelog": "ut-changelog",
     "check": "ut-check",
     "cover": "ut-cover",
+    "precover": "ut-precover",
     "lint-js": "ut-lint-js .",
     "postpublish": "ut-postpublish",
     "postversion": "ut-postversion",


### PR DESCRIPTION
Add possibility for allowing certain http status codes.
This is usable for the cases when the returned errors are expected and treated in a special way.
E.g. when attempting to get a given resource with the intention to insert it if it doesn't exist.
In cases like that the lack of existance migh not be treated as an error and logging that in files, sentry, etc.. might not be a desired action.