### PR TITLE
fix: set response and body to empty objects when there is an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ module.exports = ({utPort}) => class HttpPort extends utPort {
             }
             this.log && this.log.debug && this.log.debug(reqProps);
             // do the connection + request
-            let req = request(reqProps, (error, response, body) => {
+            let req = request(reqProps, (error, response = {}, body = {}) => {
                 const {
                     statusCode,
                     statusText,


### PR DESCRIPTION
set response and body to empty objects as if there is an error they are undefined

the error itself is something like: 
{"errno":"ECONNREFUSED","code":"ECONNREFUSED","syscall":"connect","address":"127.0.0.1","port":8099}