### PR TITLE
fix: turn function to arrow function so that this.erros is accessible

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,7 +266,8 @@ module.exports = ({utPort, registerErrors}) => class HttpPort extends utPort {
                                 } else {
                                     const parseOptions = msg.parseOptions || (this.config.parseOptions && this.config.parseOptions[response.headers['content-type']]);
                                     if (response.headers['content-type'].indexOf('/xml') !== -1 || response.headers['content-type'].indexOf('/soap+xml') !== -1) {
-                                        xml2js.parseString(body, {
+                                        const xml = reqProps.encoding ? Buffer.from(body, reqProps.encoding).toString('utf-8') : body;
+                                        xml2js.parseString(xml, {
                                             explicitArray: false,
                                             ...parseOptions
                                         }, (err, result) => {

--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ module.exports = ({utPort, registerErrors}) => class HttpPort extends utPort {
                                         xml2js.parseString(body, {
                                             explicitArray: false,
                                             ...parseOptions
-                                        }, function(err, result) {
+                                        }, (err, result) => {
                                             if (err) {
                                                 reject(this.errors['portHTTP.parser.xmlParser'](err));
                                             } else {


### PR DESCRIPTION
turn function to arrow function so that this.erros is accessible